### PR TITLE
Allow teapots to be filled from fluid containers, and allow milk pickup

### DIFF
--- a/src/main/java/knightminer/simplytea/core/config/Teapot.java
+++ b/src/main/java/knightminer/simplytea/core/config/Teapot.java
@@ -6,6 +6,7 @@ import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
 public class Teapot {
   private BooleanValue infinite_water;
   private BooleanValue fill_from_cauldron;
+  private BooleanValue fill_from_fluid_tank;
   private BooleanValue milk_cow;
   public Teapot(ForgeConfigSpec.Builder builder) {
     builder.comment("Options related to filling the teapot").push("teapot");
@@ -15,6 +16,9 @@ public class Teapot {
     fill_from_cauldron = builder.comment("If true, the teapot can be filled with water from a cauldron")
                                 .translation("simplytea.config.teapot.fill_from_cauldron")
                                 .define("fill_from_cauldron", true);
+    fill_from_fluid_tank = builder.comment("If true, the teapot can be filled with water from a fluid tank")
+                                  .translation("simplytea.config.teapot.fill_from_fluid_tank")
+                                  .define("fill_from_fluid_tank", true);
     milk_cow = builder.comment("If true, cows can be milked using a teapot to fill it with milk")
                       .translation("simplytea.config.teapot.milk_cow")
                       .define("milk_cow", true);
@@ -29,6 +33,11 @@ public class Teapot {
   /** True if teapots can be filled from a cauldron */
   public boolean fillFromCauldron() {
     return fill_from_cauldron.get();
+  }
+
+  /** True if teapots can be filled from a fluid tank */
+  public boolean fillFromFluidTank() {
+    return fill_from_fluid_tank.get();
   }
 
   /** True if teapots can be used to milk cows */

--- a/src/main/java/knightminer/simplytea/core/config/Teapot.java
+++ b/src/main/java/knightminer/simplytea/core/config/Teapot.java
@@ -2,12 +2,15 @@ package knightminer.simplytea.core.config;
 
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
+import net.minecraftforge.common.ForgeConfigSpec.IntValue;
+import net.minecraftforge.fluids.FluidType;
 
 public class Teapot {
   private BooleanValue infinite_water;
   private BooleanValue fill_from_cauldron;
   private BooleanValue fill_from_fluid_tank;
   private BooleanValue milk_cow;
+  private IntValue teapot_capacity;
   public Teapot(ForgeConfigSpec.Builder builder) {
     builder.comment("Options related to filling the teapot").push("teapot");
     infinite_water = builder.comment("If true, the teapot will not consume water source blocks when filling. It will still consume water from tank and cauldrons.")
@@ -16,12 +19,12 @@ public class Teapot {
     fill_from_cauldron = builder.comment("If true, the teapot can be filled with water from a cauldron")
                                 .translation("simplytea.config.teapot.fill_from_cauldron")
                                 .define("fill_from_cauldron", true);
-    fill_from_fluid_tank = builder.comment("If true, the teapot can be filled with water from a fluid tank")
-                                  .translation("simplytea.config.teapot.fill_from_fluid_tank")
-                                  .define("fill_from_fluid_tank", true);
     milk_cow = builder.comment("If true, cows can be milked using a teapot to fill it with milk")
                       .translation("simplytea.config.teapot.milk_cow")
                       .define("milk_cow", true);
+    teapot_capacity = builder.comment("Amount of fluid a teapot can contain")
+                             .translation("simplytea.config.teapot.teapot_capacity")
+                             .defineInRange("teapot_capacity", FluidType.BUCKET_VOLUME, 1, FluidType.BUCKET_VOLUME * 256);
     builder.pop();
   }
 
@@ -43,5 +46,10 @@ public class Teapot {
   /** True if teapots can be used to milk cows */
   public boolean canMilkCows() {
     return milk_cow.get();
+  }
+
+  /** Amount of fluid a teapot can contain */
+  public int teapotCapacity() {
+    return teapot_capacity.get();
   }
 }

--- a/src/main/java/knightminer/simplytea/core/config/Teapot.java
+++ b/src/main/java/knightminer/simplytea/core/config/Teapot.java
@@ -8,7 +8,6 @@ import net.minecraftforge.fluids.FluidType;
 public class Teapot {
   private BooleanValue infinite_water;
   private BooleanValue fill_from_cauldron;
-  private BooleanValue fill_from_fluid_tank;
   private BooleanValue milk_cow;
   private IntValue teapot_capacity;
   public Teapot(ForgeConfigSpec.Builder builder) {
@@ -22,7 +21,7 @@ public class Teapot {
     milk_cow = builder.comment("If true, cows can be milked using a teapot to fill it with milk")
                       .translation("simplytea.config.teapot.milk_cow")
                       .define("milk_cow", true);
-    teapot_capacity = builder.comment("Amount of fluid a teapot can contain")
+    teapot_capacity = builder.comment("Amount of fluid consumed when filling a teapot from a tank")
                              .translation("simplytea.config.teapot.teapot_capacity")
                              .defineInRange("teapot_capacity", FluidType.BUCKET_VOLUME, 1, FluidType.BUCKET_VOLUME * 256);
     builder.pop();
@@ -36,11 +35,6 @@ public class Teapot {
   /** True if teapots can be filled from a cauldron */
   public boolean fillFromCauldron() {
     return fill_from_cauldron.get();
-  }
-
-  /** True if teapots can be filled from a fluid tank */
-  public boolean fillFromFluidTank() {
-    return fill_from_fluid_tank.get();
   }
 
   /** True if teapots can be used to milk cows */

--- a/src/main/java/knightminer/simplytea/fluid/FluidTeapotWrapper.java
+++ b/src/main/java/knightminer/simplytea/fluid/FluidTeapotWrapper.java
@@ -3,6 +3,7 @@ package knightminer.simplytea.fluid;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import knightminer.simplytea.core.Config;
 import knightminer.simplytea.core.Registration;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
@@ -15,7 +16,6 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
-import static net.minecraftforge.fluids.FluidType.BUCKET_VOLUME;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
 public class FluidTeapotWrapper implements IFluidHandlerItem, ICapabilityProvider {
@@ -41,7 +41,7 @@ public class FluidTeapotWrapper implements IFluidHandlerItem, ICapabilityProvide
 
 	@Override
 	public int getTankCapacity(int tank) {
-		return BUCKET_VOLUME;
+		return Config.SERVER.teapot.teapotCapacity();
 	}
 
     public static boolean isWater(Fluid fluid) {
@@ -62,7 +62,7 @@ public class FluidTeapotWrapper implements IFluidHandlerItem, ICapabilityProvide
 
 	@Override
 	public int fill(FluidStack resource, FluidAction action) {
-		if (container.getCount() != 1 || !isFluidValid(0, resource) || resource.getAmount() < BUCKET_VOLUME) {
+		if (container.getCount() != 1 || !isFluidValid(0, resource) || resource.getAmount() < Config.SERVER.teapot.teapotCapacity()) {
             return 0;
         }
 		
@@ -74,7 +74,7 @@ public class FluidTeapotWrapper implements IFluidHandlerItem, ICapabilityProvide
             }
 		}
 		
-		return BUCKET_VOLUME;
+		return Config.SERVER.teapot.teapotCapacity();
 	}
 
 	@Override

--- a/src/main/java/knightminer/simplytea/fluid/FluidTeapotWrapper.java
+++ b/src/main/java/knightminer/simplytea/fluid/FluidTeapotWrapper.java
@@ -1,0 +1,99 @@
+package knightminer.simplytea.fluid;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import knightminer.simplytea.core.Registration;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
+import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.fluids.FluidStack;
+import static net.minecraftforge.fluids.FluidType.BUCKET_VOLUME;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+
+public class FluidTeapotWrapper implements IFluidHandlerItem, ICapabilityProvider {
+    private final LazyOptional<IFluidHandlerItem> holder = LazyOptional.of(() -> this);
+
+	@NotNull
+    protected ItemStack container;
+    protected FluidStack fluid = FluidStack.EMPTY;
+
+    public FluidTeapotWrapper(ItemStack container) {
+        this.container = container;
+    }
+
+    @Override
+	public int getTanks() {
+		return 1;
+	}
+
+	@Override
+	public @NotNull FluidStack getFluidInTank(int tank) {
+        return FluidStack.EMPTY;
+	}
+
+	@Override
+	public int getTankCapacity(int tank) {
+		return BUCKET_VOLUME;
+	}
+
+    public static boolean isWater(Fluid fluid) {
+        // Many modded fluids use the WATER tag to give the fluids entity interaction
+        // Only accept Fluids.WATER and not any other fluid tagged as WATER
+        return fluid.isSame(Fluids.WATER);
+    }
+
+    public static boolean isMilk(Fluid fluid) {
+        // Be more flexible with MILK because if it's tagged as MILK then it should really be milk
+        return fluid.is(Tags.Fluids.MILK) || fluid.getBucket() == Items.MILK_BUCKET;
+    }
+
+	@Override
+	public boolean isFluidValid(int tank, @NotNull FluidStack fluid) {
+		return isWater(fluid.getFluid()) || isMilk(fluid.getFluid());
+	}
+
+	@Override
+	public int fill(FluidStack resource, FluidAction action) {
+		if (container.getCount() != 1 || !isFluidValid(0, resource) || resource.getAmount() < BUCKET_VOLUME) {
+            return 0;
+        }
+		
+        if (action.execute()) {
+		    if (isWater(resource.getFluid())) {
+                this.container = new ItemStack(Registration.teapot_water);
+            } else if (isMilk(resource.getFluid())) {
+                this.container = new ItemStack(Registration.teapot_milk);
+            }
+		}
+		
+		return BUCKET_VOLUME;
+	}
+
+	@Override
+	public @NotNull FluidStack drain(FluidStack resource, FluidAction action) {
+        return FluidStack.EMPTY;
+	}
+
+	@Override
+	public @NotNull FluidStack drain(int maxDrain, FluidAction action) {
+		return FluidStack.EMPTY;
+	}
+
+	@Override
+	public @NotNull ItemStack getContainer() {
+        return container;
+	}
+
+    @Override
+	public <T> @NotNull LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction side) {
+		return ForgeCapabilities.FLUID_HANDLER_ITEM.orEmpty(capability, holder);
+	}
+}

--- a/src/main/java/knightminer/simplytea/fluid/FluidTeapotWrapper.java
+++ b/src/main/java/knightminer/simplytea/fluid/FluidTeapotWrapper.java
@@ -47,7 +47,7 @@ public class FluidTeapotWrapper implements IFluidHandlerItem, ICapabilityProvide
     public static boolean isWater(Fluid fluid) {
         // Many modded fluids use the WATER tag to give the fluids entity interaction
         // Only accept Fluids.WATER and not any other fluid tagged as WATER
-        return fluid.isSame(Fluids.WATER);
+        return fluid.isSame(Fluids.WATER) || fluid.isSame(Fluids.FLOWING_WATER);
     }
 
     public static boolean isMilk(Fluid fluid) {

--- a/src/main/java/knightminer/simplytea/item/TeapotItem.java
+++ b/src/main/java/knightminer/simplytea/item/TeapotItem.java
@@ -4,69 +4,132 @@ import knightminer.simplytea.core.Config;
 import knightminer.simplytea.core.Registration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
-import net.minecraft.tags.FluidTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.Cow;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ItemUtils;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.AbstractCauldronBlock;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.BucketPickup;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult.Type;
+import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.fluids.FluidActionResult;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidType;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+
+import java.util.Optional;
 
 public class TeapotItem extends TooltipItem {
+
 	public TeapotItem(Properties props) {
 		super(props);
 	}
 
+	// using onItemUseFirst() instead of use() because many fluid tanks will consume the interaction before it gets to use()
 	@Override
-	public InteractionResultHolder<ItemStack> use(Level world, Player player, InteractionHand hand) {
-		ItemStack stack = player.getItemInHand(hand);
+	public InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context)
+    {
+		Level world = context.getLevel();
+		if (world.isClientSide) {
+        	return InteractionResult.PASS;
+		}
+
+		Player player = context.getPlayer();
+		// Even though the context already has a blockhitresult, it does not include fluid blocks
 		BlockHitResult rayTrace = getPlayerPOVHitResult(world, player, ClipContext.Fluid.SOURCE_ONLY);
 		if (rayTrace.getType() == Type.BLOCK) {
 			BlockPos pos = rayTrace.getBlockPos();
 			BlockState state = world.getBlockState(pos);
+			Block block = state.getBlock();
+			Direction side = rayTrace.getDirection();
 
-			// we use name for lookup to prevent default fluid conflicts
-			Fluid fluid = state.getFluidState().getType();
-			if(fluid != Fluids.EMPTY) {
-				// try for water or milk using the config lists
-				Item item = null;
-				if (fluid.is(FluidTags.WATER)) {
-					item = Registration.teapot_water;
-				} // TODO: milk when mods make a standard
+			// unable to modify the block
+			if (!world.mayInteract(player, pos) || !player.mayUseItemAt(pos.relative(side), side, stack)) {
+				return InteractionResult.PASS;
+			}
 
-				// if either one is found, update the stack
-				if(item != null) {
-					// water is considered infinite unless disabled in the config
-					if(!Config.SERVER.teapot.infiniteWater()) {
-						Direction side = rayTrace.getDirection();
-						// unable to modify the block, fail
-						if (!world.mayInteract(player, pos) || !player.mayUseItemAt(pos.relative(side), side, stack) || !(state.getBlock() instanceof BucketPickup)) {
-							return new InteractionResultHolder<>(InteractionResult.FAIL, stack);
-						}
-						((BucketPickup)state.getBlock()).pickupBlock(world, pos, state);
+			// cauldron disabled in config
+			if (block instanceof AbstractCauldronBlock && !Config.SERVER.teapot.fillFromCauldron()) {
+				return InteractionResult.PASS;
+			}
+
+			Optional<Item> filledItem = Optional.empty();
+			Optional<SoundEvent> pickupSound = Optional.empty();
+			FluidState fluidState = state.getFluidState();
+
+			if (fluidState.isSource()) {
+				Fluid fluid = fluidState.getType();
+				// comparing with WATER fluid instead of WATER fluid tag, because many/most modded fluids are tagged as WATER
+				// to get water-like interactions even if the fluid is not water
+				if (fluid.isSame(Fluids.WATER)) {
+					filledItem = Optional.of(Registration.teapot_water);
+					pickupSound = ((BucketPickup)block).getPickupSound(state);
+					if (!Config.SERVER.teapot.infiniteWater()) {
+						((BucketPickup)block).pickupBlock(world, pos, state);
+					}
+				} else if (fluid.is(Tags.Fluids.MILK)) {
+					filledItem = Optional.of(Registration.teapot_milk);
+					pickupSound = ((BucketPickup)block).getPickupSound(state);
+					((BucketPickup)block).pickupBlock(world, pos, state);
+				}
+			} else if (Config.SERVER.teapot.fillFromFluidTank()) {
+				BlockEntity entity = world.getBlockEntity(pos);
+				Optional<IFluidHandler> fluidHandler = Optional.empty();
+				if (entity != null) {
+					 fluidHandler = entity.getCapability(ForgeCapabilities.FLUID_HANDLER, side).resolve();
+				}
+				if (fluidHandler.isPresent()) {
+					FluidActionResult fillResult = FluidUtil.tryFillContainer(new ItemStack(Items.BUCKET), fluidHandler.get(), FluidType.BUCKET_VOLUME, player, false);
+					FluidStack fluidStack = fillResult.success ? FluidUtil.getFluidContained(fillResult.getResult()).orElseGet(() -> FluidStack.EMPTY) : FluidStack.EMPTY;
+
+					if (fluidStack.isEmpty() || fluidStack.getAmount() != FluidType.BUCKET_VOLUME) {
+						return InteractionResult.PASS;
+					}
+						
+					// comparing with WATER fluid instead of WATER fluid tag, because many/most modded fluids are tagged as WATER
+					// to get water-like interactions even if the fluid is not water
+					if (fluidStack.getFluid().isSame(Fluids.WATER)) {
+						filledItem = Optional.of(Registration.teapot_water);
+					} else if (fluidStack.getFluid().is(Tags.Fluids.MILK)) {
+						filledItem = Optional.of(Registration.teapot_milk);
 					}
 
-					stack = ItemUtils.createFilledResult(stack, player, new ItemStack(item));
+					if (filledItem.isPresent()) {
+						FluidUtil.tryFillContainer(new ItemStack(Items.BUCKET), fluidHandler.get(), FluidType.BUCKET_VOLUME, player, true);
+					}
 
-					// TODO: fluid sound based on fluid
-					player.playSound(SoundEvents.BUCKET_FILL, 1.0f, 1.0f);
-					return new InteractionResultHolder<>(InteractionResult.SUCCESS, stack);
 				}
 			}
+
+			if (filledItem.isPresent()) {
+				if (pickupSound.isPresent()) {
+					player.playSound(pickupSound.get(), 1.0f, 1.0f);
+				}
+				player.setItemInHand(context.getHand(), ItemUtils.createFilledResult(stack.copy(), player, new ItemStack(filledItem.get())));
+				return InteractionResult.SUCCESS;
+			}
 		}
-		return new InteractionResultHolder<>(InteractionResult.FAIL, stack);
+
+		return InteractionResult.PASS;
 	}
 
 	@Override

--- a/src/main/java/knightminer/simplytea/item/TeapotItem.java
+++ b/src/main/java/knightminer/simplytea/item/TeapotItem.java
@@ -1,28 +1,36 @@
 package knightminer.simplytea.item;
 
+import org.jetbrains.annotations.Nullable;
+
 import knightminer.simplytea.core.Config;
 import knightminer.simplytea.core.Registration;
+import knightminer.simplytea.fluid.FluidTeapotWrapper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
-import net.minecraft.tags.FluidTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.Cow;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ItemUtils;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BucketPickup;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.Fluid;
-import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult.Type;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.fluids.FluidActionResult;
+import net.minecraftforge.fluids.FluidType;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+
+import java.util.Optional;
 
 public class TeapotItem extends TooltipItem {
 	public TeapotItem(Properties props) {
@@ -33,40 +41,55 @@ public class TeapotItem extends TooltipItem {
 	public InteractionResultHolder<ItemStack> use(Level world, Player player, InteractionHand hand) {
 		ItemStack stack = player.getItemInHand(hand);
 		BlockHitResult rayTrace = getPlayerPOVHitResult(world, player, ClipContext.Fluid.SOURCE_ONLY);
-		if (rayTrace.getType() == Type.BLOCK) {
-			BlockPos pos = rayTrace.getBlockPos();
-			BlockState state = world.getBlockState(pos);
+		if (rayTrace.getType() != Type.BLOCK) {
+			return InteractionResultHolder.pass(stack);
+		}
+		
+		BlockPos pos = rayTrace.getBlockPos();
+		Direction side = rayTrace.getDirection();
+		BlockState state = world.getBlockState(pos);
 
-			// we use name for lookup to prevent default fluid conflicts
-			Fluid fluid = state.getFluidState().getType();
-			if(fluid != Fluids.EMPTY) {
-				// try for water or milk using the config lists
-				Item item = null;
-				if (fluid.is(FluidTags.WATER)) {
-					item = Registration.teapot_water;
-				} // TODO: milk when mods make a standard
+		if (!world.mayInteract(player, pos) || !player.mayUseItemAt(pos.relative(side), side, stack)) {
+			return InteractionResultHolder.fail(stack);
+		}
 
-				// if either one is found, update the stack
-				if(item != null) {
-					// water is considered infinite unless disabled in the config
-					if(!Config.SERVER.teapot.infiniteWater()) {
-						Direction side = rayTrace.getDirection();
-						// unable to modify the block, fail
-						if (!world.mayInteract(player, pos) || !player.mayUseItemAt(pos.relative(side), side, stack) || !(state.getBlock() instanceof BucketPickup)) {
-							return new InteractionResultHolder<>(InteractionResult.FAIL, stack);
-						}
-						((BucketPickup)state.getBlock()).pickupBlock(world, pos, state);
-					}
-
-					stack = ItemUtils.createFilledResult(stack, player, new ItemStack(item));
-
-					// TODO: fluid sound based on fluid
-					player.playSound(SoundEvents.BUCKET_FILL, 1.0f, 1.0f);
-					return new InteractionResultHolder<>(InteractionResult.SUCCESS, stack);
+		ItemStack filledStack = ItemStack.EMPTY;
+		if (state.getBlock() instanceof BucketPickup bucketPickup) {
+			// special case for infinite water
+			if (FluidTeapotWrapper.isWater(state.getFluidState().getType()) && !Config.SERVER.teapot.infiniteWater()) {
+				filledStack = new ItemStack(Registration.teapot_water);
+				Optional<SoundEvent> sound = bucketPickup.getPickupSound(state);
+				if (sound.isPresent()) {
+					player.playSound(sound.get(), 1.0f, 1.0f);
+				}
+			}
+			
+			// should work in most cases
+			if (filledStack.isEmpty()) {
+				FluidActionResult actionResult = FluidUtil.tryPickUpFluid(stack, player, world, pos, side);
+				if (actionResult.isSuccess()) {
+					filledStack = actionResult.getResult();
 				}
 			}
 		}
-		return new InteractionResultHolder<>(InteractionResult.FAIL, stack);
+
+		// if pickup block doesn't work, try accessing the fluid handler
+		if (filledStack.isEmpty()) {
+			Optional<IFluidHandler> fluidSource = FluidUtil.getFluidHandler(world, pos, side).resolve();
+			if (fluidSource.isPresent()) {
+				FluidActionResult actionResult = FluidUtil.tryFillContainer(stack, fluidSource.get(), FluidType.BUCKET_VOLUME, player, true);
+				if (actionResult.isSuccess()) {
+					filledStack = actionResult.getResult();
+				}
+			}
+		}
+
+		if (!filledStack.isEmpty()) {
+			ItemStack filledResult = ItemUtils.createFilledResult(stack, player, filledStack);
+			return InteractionResultHolder.sidedSuccess(filledResult, world.isClientSide());
+		}
+
+		return InteractionResultHolder.fail(stack);
 	}
 
 	@Override
@@ -81,5 +104,11 @@ public class TeapotItem extends TooltipItem {
 			return InteractionResult.SUCCESS;
 		}
 		return InteractionResult.PASS;
+	}
+
+	@Nullable
+	@Override
+	public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt) {
+		return new FluidTeapotWrapper(stack);
 	}
 }

--- a/src/main/java/knightminer/simplytea/item/TeapotItem.java
+++ b/src/main/java/knightminer/simplytea/item/TeapotItem.java
@@ -63,20 +63,9 @@ public class TeapotItem extends TooltipItem {
 				}
 			}
 			
-			// should work in most cases
+			// use teapot like a bucket to get fluid, should work in most cases
 			if (filledStack.isEmpty()) {
 				FluidActionResult actionResult = FluidUtil.tryPickUpFluid(stack, player, world, pos, side);
-				if (actionResult.isSuccess()) {
-					filledStack = actionResult.getResult();
-				}
-			}
-		}
-
-		// if pickup block doesn't work, try accessing the fluid handler
-		if (filledStack.isEmpty()) {
-			Optional<IFluidHandler> fluidSource = FluidUtil.getFluidHandler(world, pos, side).resolve();
-			if (fluidSource.isPresent()) {
-				FluidActionResult actionResult = FluidUtil.tryFillContainer(stack, fluidSource.get(), Config.SERVER.teapot.teapotCapacity(), player, true);
 				if (actionResult.isSuccess()) {
 					filledStack = actionResult.getResult();
 				}

--- a/src/main/java/knightminer/simplytea/item/TeapotItem.java
+++ b/src/main/java/knightminer/simplytea/item/TeapotItem.java
@@ -26,7 +26,6 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult.Type;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.fluids.FluidActionResult;
-import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
@@ -77,7 +76,7 @@ public class TeapotItem extends TooltipItem {
 		if (filledStack.isEmpty()) {
 			Optional<IFluidHandler> fluidSource = FluidUtil.getFluidHandler(world, pos, side).resolve();
 			if (fluidSource.isPresent()) {
-				FluidActionResult actionResult = FluidUtil.tryFillContainer(stack, fluidSource.get(), FluidType.BUCKET_VOLUME, player, true);
+				FluidActionResult actionResult = FluidUtil.tryFillContainer(stack, fluidSource.get(), Config.SERVER.teapot.teapotCapacity(), player, true);
 				if (actionResult.isSuccess()) {
 					filledStack = actionResult.getResult();
 				}


### PR DESCRIPTION
Changes to teapot to support picking up water or milk from any block with fluid handler capabilities.
Also added new config option to allow/disallow pickup from fluid handler blocks.

Milk (if it's enabled) is also supported in more cases.

Tested with Flopper, Cooking for Blockheads sink and cow bottle, and Mekanism fluid tank.

Compiled/tested against 1.19, but the changes should also work for the 1.20 branch.

Closes #46 

Happy Modtoberfest 2024!